### PR TITLE
Reverse proxy setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ These are things that I want to implement here.
 - [x] Monitoring (prometheus)
 - [x] Docker
 - [x] CI/CD
+- [x] Reverse Proxy (nginx)
 - [ ] GraphQL API
 - [ ] gRPC Layer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,24 @@ services:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:3001"]
       interval: 10s
       retries: 5
+  
+  nginx:
+    image: nginx:alpine
+    container_name: nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - devtasker
+      - prometheus
+      - grafana
+    networks:
+      - monitor
+    # healthcheck:
+    #   test: ["CMD", "wget", "--spider", "-q", "http://localhost"]
+    #   interval: 10s
+    #   retries: 5
 
 volumes:
   db_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,10 +82,10 @@ services:
       - grafana
     networks:
       - monitor
-    # healthcheck:
-    #   test: ["CMD", "wget", "--spider", "-q", "http://localhost"]
-    #   interval: 10s
-    #   retries: 5
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://devtasker:3000/health"] # check if nginx can reach devtasker
+      interval: 10s
+      retries: 5
 
 volumes:
   db_data:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -23,4 +23,14 @@ server {
         proxy_redirect off;
         
     }
+
+    # Disable logging for /health
+    location = /health {
+        proxy_pass http://devtasker:3000;
+        proxy_set_header Host $host; 
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_redirect off;
+        access_log off;
+    }
 }

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,3 +1,6 @@
+# Limit each IP address can make 10 request/s
+limit_req_zone $binary_remote_addr zone=mylimit:10m rate=10r/s;
+
 server {
     listen 80;
 
@@ -8,5 +11,16 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_redirect off;
+    }
+
+    # Apply the rate limiter for these endpoint and methods
+    location /api/task {
+        limit_req zone=mylimit burst=20;
+        proxy_pass http://devtasker:3000;
+        proxy_set_header Host $host; 
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_redirect off;
+        
     }
 }

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+
+    # Reverse proxy for devtasker, from localhost:3000/ to localhost/
+    location / {
+        proxy_pass http://devtasker:3000;
+        proxy_set_header Host $host; 
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_redirect off;
+    }
+}


### PR DESCRIPTION
Setup reverse proxy using Nginx
1. Redirect `localhost` to `localhost:3000` to access the devtasker app
2. Apply rate limit for `/api/task`
3. Disable nginx log for `/health`