### PR TITLE
Setup K8s (minikube)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
   postgres:
     image: postgres
     container_name: postgres
+    ports:
+      - 5432:5432
     restart: unless-stopped
     networks:
       - monitor

--- a/k8s/db-data-persistentvolumeclaim.yaml
+++ b/k8s/db-data-persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: db-data
+  name: db-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/k8s/devtasker-deployment.yaml
+++ b/k8s/devtasker-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.36.0 (ae2a39403)
+  labels:
+    io.kompose.service: devtasker
+  name: devtasker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: devtasker
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.36.0 (ae2a39403)
+      labels:
+        io.kompose.service: devtasker
+    spec:
+      containers:
+        - envFrom:
+            - configMapRef:
+                name: devtasker-env
+          image: iqbalpa/go-devtasker:latest
+          livenessProbe:
+            exec:
+              command:
+                - curl
+                - -f
+                - http://localhost:3000/health
+            failureThreshold: 5
+            periodSeconds: 10
+          name: devtasker
+          ports:
+            - containerPort: 3000
+              protocol: TCP
+      restartPolicy: Always

--- a/k8s/devtasker-env-configmap.yaml
+++ b/k8s/devtasker-env-configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  APP_ENV: dev
+  DB_HOST: postgres
+  DB_NAME: devtasker
+  DB_PASSWORD: iqbalpahlevi
+  DB_PORT: "5432"
+  DB_USER: postgres
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: devtasker-devtasker-env
+  name: devtasker-env

--- a/k8s/devtasker-service.yaml
+++ b/k8s/devtasker-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.36.0 (ae2a39403)
+  labels:
+    io.kompose.service: devtasker
+  name: devtasker
+spec:
+  ports:
+    - name: "3000"
+      port: 3000
+      targetPort: 3000
+  selector:
+    io.kompose.service: devtasker

--- a/k8s/grafana-cm0-configmap.yaml
+++ b/k8s/grafana-cm0-configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data:
+  datasource.yml: |
+    apiVersion: 1
+
+    datasources:
+    - name: Prometheus
+      type: prometheus
+      url: http://prometheus:9090
+      isDefault: true
+      access: proxy
+      editable: true
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: grafana
+  name: grafana-cm0

--- a/k8s/grafana-data-persistentvolumeclaim.yaml
+++ b/k8s/grafana-data-persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: grafana-data
+  name: grafana-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/k8s/grafana-deployment.yaml
+++ b/k8s/grafana-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.36.0 (ae2a39403)
+  labels:
+    io.kompose.service: grafana
+  name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: grafana
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.36.0 (ae2a39403)
+      labels:
+        io.kompose.service: grafana
+    spec:
+      containers:
+        - envFrom:
+            - configMapRef:
+                name: grafana-env
+          image: grafana/grafana
+          livenessProbe:
+            exec:
+              command:
+                - wget
+                - --spider
+                - -q
+                - http://localhost:3001
+            failureThreshold: 5
+            periodSeconds: 10
+          name: grafana
+          ports:
+            - containerPort: 3001
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/grafana/provisioning/datasources
+              name: grafana-cm0
+            - mountPath: /grafana
+              name: grafana-data
+      restartPolicy: Always
+      volumes:
+        - configMap:
+            name: grafana-cm0
+          name: grafana-cm0
+        - name: grafana-data
+          persistentVolumeClaim:
+            claimName: grafana-data

--- a/k8s/grafana-env-configmap.yaml
+++ b/k8s/grafana-env-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  GF_SECURITY_ADMIN_PASSWORD: grafana
+  GF_SECURITY_ADMIN_USER: admin
+  GF_SERVER_HTTP_PORT: "3001"
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: grafana-grafana-env
+  name: grafana-env

--- a/k8s/grafana-service.yaml
+++ b/k8s/grafana-service.yaml
@@ -8,9 +8,11 @@ metadata:
     io.kompose.service: grafana
   name: grafana
 spec:
+  type: NodePort
   ports:
     - name: "3001"
       port: 3001
       targetPort: 3001
+      nodePort: 31001
   selector:
     io.kompose.service: grafana

--- a/k8s/grafana-service.yaml
+++ b/k8s/grafana-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.36.0 (ae2a39403)
+  labels:
+    io.kompose.service: grafana
+  name: grafana
+spec:
+  ports:
+    - name: "3001"
+      port: 3001
+      targetPort: 3001
+  selector:
+    io.kompose.service: grafana

--- a/k8s/nginx-cm0-configmap.yaml
+++ b/k8s/nginx-cm0-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  default.conf: "# Limit each IP address can make 10 request/s\nlimit_req_zone $binary_remote_addr zone=mylimit:10m rate=10r/s;\n\nserver {\n    listen 80;\n\n    # Reverse proxy for devtasker, from localhost:3000/ to localhost/\n    location / {\n        proxy_pass http://devtasker:3000;\n        proxy_set_header Host $host; \n        proxy_set_header X-Real-IP $remote_addr;\n        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n        proxy_redirect off;\n    }\n\n    # Apply the rate limiter for these endpoint and methods\n    location /api/task {\n        limit_req zone=mylimit burst=20;\n        proxy_pass http://devtasker:3000;\n        proxy_set_header Host $host; \n        proxy_set_header X-Real-IP $remote_addr;\n        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n        proxy_redirect off;\n        \n    }\n\n    # Disable logging for /health\n    location = /health {\n        proxy_pass http://devtasker:3000;\n        proxy_set_header Host $host; \n        proxy_set_header X-Real-IP $remote_addr;\n        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n        proxy_redirect off;\n        access_log off;\n    }\n}\n"
+kind: ConfigMap
+metadata:
+  annotations:
+    use-subpath: "true"
+  labels:
+    io.kompose.service: nginx
+  name: nginx-cm0

--- a/k8s/nginx-deployment.yaml
+++ b/k8s/nginx-deployment.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.36.0 (ae2a39403)
+  labels:
+    io.kompose.service: nginx
+  name: nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: nginx
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.36.0 (ae2a39403)
+      labels:
+        io.kompose.service: nginx
+    spec:
+      containers:
+        - image: nginx:alpine
+          livenessProbe:
+            exec:
+              command:
+                - wget
+                - --spider
+                - -q
+                - http://devtasker:3000/health
+            failureThreshold: 5
+            periodSeconds: 10
+          name: nginx
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/nginx/conf.d/default.conf
+              name: nginx-cm0
+              readOnly: true
+              subPath: default.conf
+      restartPolicy: Always
+      volumes:
+        - configMap:
+            items:
+              - key: default.conf
+                path: default.conf
+            name: nginx-cm0
+          name: nginx-cm0

--- a/k8s/nginx-service.yaml
+++ b/k8s/nginx-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.36.0 (ae2a39403)
+  labels:
+    io.kompose.service: nginx
+  name: nginx
+spec:
+  ports:
+    - name: "80"
+      port: 80
+      targetPort: 80
+  selector:
+    io.kompose.service: nginx

--- a/k8s/nginx-service.yaml
+++ b/k8s/nginx-service.yaml
@@ -8,9 +8,11 @@ metadata:
     io.kompose.service: nginx
   name: nginx
 spec:
+  type: NodePort
   ports:
     - name: "80"
       port: 80
       targetPort: 80
+      nodePort: 31000
   selector:
     io.kompose.service: nginx

--- a/k8s/postgres-deployment.yaml
+++ b/k8s/postgres-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.36.0 (ae2a39403)
+  labels:
+    io.kompose.service: postgres
+  name: postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: postgres
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.36.0 (ae2a39403)
+      labels:
+        io.kompose.service: postgres
+    spec:
+      containers:
+        - envFrom:
+            - configMapRef:
+                name: postgres-env
+          image: postgres
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - postgres
+            failureThreshold: 5
+            periodSeconds: 10
+          name: postgres
+          ports:
+            - containerPort: 5432
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: db-data
+      restartPolicy: Always
+      volumes:
+        - name: db-data
+          persistentVolumeClaim:
+            claimName: db-data

--- a/k8s/postgres-env-configmap.yaml
+++ b/k8s/postgres-env-configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  POSTGRES_DB: devtasker
+  POSTGRES_PASSWORD: iqbalpahlevi
+  POSTGRES_USER: postgres
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: postgres-postgres-env
+  name: postgres-env

--- a/k8s/postgres-service.yaml
+++ b/k8s/postgres-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.36.0 (ae2a39403)
+  labels:
+    io.kompose.service: postgres
+  name: postgres
+spec:
+  ports:
+    - name: "5432"
+      port: 5432
+      targetPort: 5432
+  selector:
+    io.kompose.service: postgres

--- a/k8s/prom-data-persistentvolumeclaim.yaml
+++ b/k8s/prom-data-persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: prom-data
+  name: prom-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi

--- a/k8s/prometheus-cm0-configmap.yaml
+++ b/k8s/prometheus-cm0-configmap.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 5s
+    scrape_configs:
+    - job_name: devtasker
+      honor_timestamps: true
+      scrape_interval: 5s
+      metrics_path: /metrics
+      scheme: http
+      static_configs:
+      - targets:
+        - devtasker:3000
+kind: ConfigMap
+metadata:
+  labels:
+    io.kompose.service: prometheus
+  name: prometheus-cm0

--- a/k8s/prometheus-deployment.yaml
+++ b/k8s/prometheus-deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.36.0 (ae2a39403)
+  labels:
+    io.kompose.service: prometheus
+  name: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: prometheus
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.36.0 (ae2a39403)
+      labels:
+        io.kompose.service: prometheus
+    spec:
+      containers:
+        - args:
+            - --config.file=/etc/prometheus/prometheus.yml
+          image: prom/prometheus
+          livenessProbe:
+            exec:
+              command:
+                - wget
+                - --spider
+                - -q
+                - http://localhost:9090/-/healthy
+            failureThreshold: 5
+            periodSeconds: 10
+          name: prometheus
+          ports:
+            - containerPort: 9090
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/prometheus
+              name: prometheus-cm0
+            - mountPath: /prometheus
+              name: prom-data
+      restartPolicy: Always
+      volumes:
+        - configMap:
+            name: prometheus-cm0
+          name: prometheus-cm0
+        - name: prom-data
+          persistentVolumeClaim:
+            claimName: prom-data

--- a/k8s/prometheus-service.yaml
+++ b/k8s/prometheus-service.yaml
@@ -8,9 +8,11 @@ metadata:
     io.kompose.service: prometheus
   name: prometheus
 spec:
+  type: NodePort
   ports:
     - name: "9090"
       port: 9090
       targetPort: 9090
+      nodePort: 31002
   selector:
     io.kompose.service: prometheus

--- a/k8s/prometheus-service.yaml
+++ b/k8s/prometheus-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert
+    kompose.version: 1.36.0 (ae2a39403)
+  labels:
+    io.kompose.service: prometheus
+  name: prometheus
+spec:
+  ports:
+    - name: "9090"
+      port: 9090
+      targetPort: 9090
+  selector:
+    io.kompose.service: prometheus


### PR DESCRIPTION
This PR introduces Kubernetes support for the devtasker application, allowing it to be deployed and managed in a
  Kubernetes cluster. The changes include adding Kubernetes configuration files, updating the docker-compose.yml file,
  and modifying the README.md to include instructions for running the application with Minikube.

  Changes:


   - Added Kubernetes Configuration:
       - Added Kubernetes configuration files for all services (devtasker, nginx, postgres, grafana, prometheus) in the
          k8s/ directory.
       - These configurations were generated using kompose convert and then manually adjusted.
   - Updated `docker-compose.yml`:
       - Exposed the PostgreSQL port to allow connections from outside the Docker network.
   - Updated `README.md`:
       - Added a new section with instructions on how to run the application using Minikube.
       - Included details on how to access the application and other services.

  How to Test:


   1. Start Minikube:
```
minikube start
```

   2. Apply the Kubernetes configurations:

```
kubectl apply -f k8s/
```

   3. Access the application at http://[minikube-ip]:31000.